### PR TITLE
fix: dead link to RailsConf talk

### DIFF
--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -34,6 +34,6 @@
           %li
             %a{href: "https://twitter.com/firehoseio"} Follow Firehose.io on Twitter
           %li
-            %a{href: "http://confreaks.com/videos/870-railsconf2012-realtime-web-applications-with-streaming-rest"} Watch the RailsConf Talk
+            %a{href: "https://www.youtube.com/watch?v=N6kHjXtLspw"} Watch the RailsConf Talk
     %section.paper.white-area
       .container~yield


### PR DESCRIPTION
The previous link no longer resolves so link directly to the youtube
video instead.